### PR TITLE
fix: count cpu's correctly when process name includes the word processor

### DIFF
--- a/get_cpus.sh
+++ b/get_cpus.sh
@@ -49,7 +49,7 @@ if [ -n "${quota:-}" ] && [ -n "${period:-}" ]; then
     cpus=1
   fi
 else
-  cpus=$(grep -c processor /proc/cpuinfo)
+  cpus=$(grep -c ^processor /proc/cpuinfo)
 fi
 
 verbose "CPUs:"

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -7,7 +7,7 @@ readonly script_dir
 
 cd "$script_dir/.."
 
-machine_cpus=$(grep -c processor /proc/cpuinfo)
+machine_cpus=$(grep -c ^processor /proc/cpuinfo)
 
 docker_cmd=(docker run --rm -v "${PWD}:${PWD}" -w "${PWD}" -e VERBOSE -e DEBUG)
 


### PR DESCRIPTION
Fixes a bug someone found running Immich where we utilised this script.
The script can double count cores if the process name includes the word "processor"
We use this script over on Immich and a user found when running docker within a VM, the processor name can end up being something like "Common KVM processor", so ensuring that grep only detects "processor" at the start of the line fixes it double counting cores.

Thought as this script helped us out I would commit it back here in return :smile: 