### PR TITLE
Avoid failing when the CPU period is zero

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,9 @@
+enable=add-default-case
+enable=avoid-nullary-conditions
+enable=check-extra-masked-returns
+enable=check-set-e-suppressed
+enable=check-unassigned-uppercase
+enable=deprecate-which
+enable=quote-safe-variables
+enable=require-double-brackets
+enable=require-variable-braces

--- a/get_cpus.sh
+++ b/get_cpus.sh
@@ -43,6 +43,13 @@ else
   fi
 fi
 
+# This is theoretically not possible, but:
+# https://github.com/blakeblackshear/frigate/discussions/11755#discussioncomment-10304356
+if [ -n "${period:-}" ] && [ "${period:-}" -eq 0 ]; then
+  warning "CPU period is 0. Falling back to /proc/cpuinfo."
+  unset quota period
+fi
+
 if [ -n "${quota:-}" ] && [ -n "${period:-}" ]; then
   cpus=$((quota / period))
   if [ "$cpus" -eq 0 ]; then

--- a/get_cpus.sh
+++ b/get_cpus.sh
@@ -20,7 +20,7 @@ if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
   verbose "cgroup v2 detected."
   if [ -f /sys/fs/cgroup/cpu.max ]; then
     read -r quota period </sys/fs/cgroup/cpu.max
-    if [ "$quota" = "max" ]; then
+    if [ "${quota}" = "max" ]; then
       verbose "No CPU limits set."
       unset quota period
     fi
@@ -34,7 +34,7 @@ else
     quota=$(cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us)
     period=$(cat /sys/fs/cgroup/cpu/cpu.cfs_period_us)
 
-    if [ "$quota" = "-1" ]; then
+    if [ "${quota}" = "-1" ]; then
       verbose "No CPU limits set."
       unset quota period
     fi
@@ -52,7 +52,7 @@ fi
 
 if [ -n "${quota:-}" ] && [ -n "${period:-}" ]; then
   cpus=$((quota / period))
-  if [ "$cpus" -eq 0 ]; then
+  if [ "${cpus}" -eq 0 ]; then
     cpus=1
   fi
 else
@@ -60,4 +60,4 @@ else
 fi
 
 verbose "CPUs:"
-printf '%s' "$cpus"
+printf '%s' "${cpus}"

--- a/get_memory.sh
+++ b/get_memory.sh
@@ -20,7 +20,7 @@ if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
   verbose "cgroup v2 detected."
   if [ -f /sys/fs/cgroup/memory.max ]; then
     memory_bytes=$(cat /sys/fs/cgroup/memory.max)
-    if [ "$memory_bytes" = "max" ]; then
+    if [ "${memory_bytes}" = "max" ]; then
       verbose "No memory limits set."
       unset memory_bytes
     fi
@@ -34,7 +34,7 @@ else
     memory_bytes=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
     memory_kb=$((memory_bytes / 1024))
     proc_memory_kb=$(grep MemTotal /proc/meminfo | awk '{print $2}')
-    if [ "$memory_kb" -ge "$proc_memory_kb" ]; then
+    if [ "${memory_kb}" -ge "${proc_memory_kb}" ]; then
       verbose "No memory limits set."
       unset memory_bytes
     fi
@@ -53,4 +53,4 @@ else
 fi
 
 verbose "Memory (MB):"
-printf '%s' "$memory_mb"
+printf '%s' "${memory_mb}"

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -5,9 +5,7 @@ set -euxo pipefail
 script_dir=$(dirname "$0")
 readonly script_dir
 
-cd "$script_dir/.."
-
-machine_cpus=$(grep -c ^processor /proc/cpuinfo)
+cd "${script_dir}/.."
 
 docker_cmd=(docker run --rm -v "${PWD}:${PWD}" -w "${PWD}" -e VERBOSE -e DEBUG)
 
@@ -16,19 +14,22 @@ function expect() {
   local input
   input=$(cat /dev/stdin)
 
-  if [ "$input" == "$expected" ]; then
+  if [[ "${input}" == "${expected}" ]]; then
     echo "Test passed" >&2
   else
     echo "Test failed" >&2
-    echo "Expected: $expected" >&2
-    echo "Got: $input" >&2
+    echo "Expected: ${expected}" >&2
+    echo "Got: ${input}" >&2
     exit 1
   fi
 }
 
-"${docker_cmd[@]}" alpine ./get_cpus.sh | expect "$machine_cpus"
+## get_cpus.sh test
+machine_cpus=$(grep -c ^processor /proc/cpuinfo)
 
-"${docker_cmd[@]}" ubuntu ./get_cpus.sh | expect "$machine_cpus"
+"${docker_cmd[@]}" alpine ./get_cpus.sh | expect "${machine_cpus}"
+
+"${docker_cmd[@]}" ubuntu ./get_cpus.sh | expect "${machine_cpus}"
 
 "${docker_cmd[@]}" --cpus 2 alpine ./get_cpus.sh | expect 2
 
@@ -36,12 +37,27 @@ function expect() {
 
 "${docker_cmd[@]}" --cpus 1.5 alpine ./get_cpus.sh | expect 1
 
+# test period=0
+tmp_cpu_file=$(mktemp)
+trap 'rm -f "${tmp_cpu_file}"' EXIT
+# detect if test system is running under cgroup v1 or v2
+if [[ -f /sys/fs/cgroup/cgroup.controllers ]]; then
+  echo "200000 0" | tee "${tmp_cpu_file}"
+  period_args=(--volume "${tmp_cpu_file}:/sys/fs/cgroup/cpu.max")
+else
+  echo "0" | tee "${tmp_cpu_file}"
+  period_args=(--volume "${tmp_cpu_file}:/sys/fs/cgroup/cpu/cpu.cfs_period_us")
+fi
+
+"${docker_cmd[@]}" --cpus 2 "${period_args[@]}" alpine ./get_cpus.sh | expect "${machine_cpus}"
+
+## get_memory.sh tests
 machine_memory=$(grep MemTotal /proc/meminfo | awk '{print $2}')
 machine_memory=$((machine_memory / 1024))
 
-"${docker_cmd[@]}" alpine ./get_memory.sh | expect "$machine_memory"
+"${docker_cmd[@]}" alpine ./get_memory.sh | expect "${machine_memory}"
 
-"${docker_cmd[@]}" ubuntu ./get_memory.sh | expect "$machine_memory"
+"${docker_cmd[@]}" ubuntu ./get_memory.sh | expect "${machine_memory}"
 
 "${docker_cmd[@]}" --memory 500mb alpine ./get_memory.sh | expect 500
 


### PR DESCRIPTION
And instead, fallback to counting CPUs from `/proc/cpuinfo` instead.

This situation is theoretically not possible, but it has happened as per:

- https://github.com/blakeblackshear/frigate/discussions/11755#discussioncomment-10304356
- https://github.com/blakeblackshear/frigate/pull/13271
